### PR TITLE
Fix mac sed

### DIFF
--- a/focused_crawler/script/build_model.sh
+++ b/focused_crawler/script/build_model.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 DIRECTORY=$1 #Directory that contain training examples. it should have two subdirectories: positive and negative
 OUTPUT=$2 #output directory
 mkdir -p $OUTPUT


### PR DESCRIPTION
Fixes build_model.sh on OSX
- Fixes OSX sed not recognising newline
- Fixes echo not recognizing '-n' when executed with sh
